### PR TITLE
fix: set option --drawio-desktop-headless as a boolean flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Option `--drawio-desktop-headless` wasn't not properly set as a boolean flag
+
 ## [1.3.0] - 2025-03-02
 
 ### Added

--- a/src/bin/drawio-exporter/commands/exporter.rs
+++ b/src/bin/drawio-exporter/commands/exporter.rs
@@ -14,7 +14,8 @@ pub fn args() -> Vec<Arg> {
             .long("application"),
         Arg::new("drawio-desktop-headless")
             .help("Enable Draw.io Desktop headless mode")
-            .long("drawio-desktop-headless"),
+            .long("drawio-desktop-headless")
+            .action(ArgAction::SetTrue),
         Arg::new("format")
             .help("Exported format")
             .value_name("format")
@@ -113,7 +114,10 @@ pub fn args() -> Vec<Arg> {
 pub fn exec(args: &ArgMatches) -> Result<()> {
     exporter(ExporterOptions {
         application: args.get_one("application").unwrap(),
-        drawio_desktop_headless: args.contains_id("drawio-desktop-headless"),
+        drawio_desktop_headless: args
+            .get_one::<bool>("drawio-desktop-headless")
+            .copied()
+            .unwrap(),
         folder: args.get_one("folder").unwrap(),
         on_filesystem_changes: args.get_one::<bool>("on-changes").copied().unwrap(),
         on_git_changes_since_reference: args.get_one("git-reference"),


### PR DESCRIPTION
Seem to be introduce with the edition 2024 and the latest release