### PR TITLE
ci: fix clippy lint failures and RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/drawio_exporter/core/explorer/git_repository.rs
+++ b/src/drawio_exporter/core/explorer/git_repository.rs
@@ -18,7 +18,7 @@ pub fn explore_path(path: &Path, git_reference: &str) -> Result<Vec<(PathBuf, Mx
 
 fn collect_files_from_git(root_path: &Path, git_reference: &str) -> Result<Vec<PathBuf>> {
     let repo = Repository::discover(root_path)
-        .with_context(|| format!("need to be a git repository {}", &root_path.display()))?;
+        .with_context(|| format!("need to be a git repository {}", root_path.display()))?;
     let mut opts = DiffOptions::new();
     let old_tree = reference_as_tree(&repo, git_reference).with_context(|| {
         format!(
@@ -33,7 +33,7 @@ fn collect_files_from_git(root_path: &Path, git_reference: &str) -> Result<Vec<P
             format!(
                 "can't found modified files from {} under {}",
                 repo.path().display(),
-                &root_path.display()
+                root_path.display()
             )
         })?;
 

--- a/src/drawio_exporter/ops/exporter.rs
+++ b/src/drawio_exporter/ops/exporter.rs
@@ -146,7 +146,7 @@ pub fn exporter(options: ExporterOptions<'_>) -> Result<()> {
         }
         Some(git_reference) => git_repository::explore_path(&input_path, git_reference),
     }
-    .with_context(|| format!("can't explore path {}", &input_path.display()))?;
+    .with_context(|| format!("can't explore path {}", input_path.display()))?;
 
     let drawio_desktop = DrawioDesktop::new(options.application, options.drawio_desktop_headless)?;
 

--- a/tests/commands/exporter_option_git_ref.rs
+++ b/tests/commands/exporter_option_git_ref.rs
@@ -44,7 +44,7 @@ fn export_using_option_git_ref_on_invalid_ref() -> Result<()> {
 Caused by:
     0: can't found reference WRONG_REFERENCE on {}{}
     1: revspec 'WRONG_REFERENCE' not found; class=Reference (4); code=NotFound (-3)",
-        &drawio_exporter.current_dir.display(),
+        drawio_exporter.current_dir.display(),
         Path::new(".").canonicalize()?.join(".git").display(),
         path::MAIN_SEPARATOR
     );

--- a/tests/commands/issue_svg_shadow.rs
+++ b/tests/commands/issue_svg_shadow.rs
@@ -13,7 +13,7 @@ fn export_svg_with_shadow() -> Result<()> {
 
     let output_err = format!(
         "Export failed: {}/svg_shadow/svg_shadow.drawio",
-        &drawio_exporter.current_dir.display()
+        drawio_exporter.current_dir.display()
     );
 
     drawio_exporter


### PR DESCRIPTION
Both are pre-existing on v1.x and currently block every dependabot PR:

- Rust 1.97's `useless_borrows_in_formatting` clippy lint now fires on `&path.display()` in `format!` calls; with `RUSTFLAGS=-Dwarnings` this hard-fails the build check.
- `crossbeam-epoch` 0.9.18 (transitive via `ignore` -> `crossbeam-deque`) is flagged by RUSTSEC-2026-0204; bumped to 0.9.20.

Landing this on v1.x so dependabot PRs #121 and #122 can be rebased and go green.