### PR TITLE
ci: install just and cargo-audit via mise

### DIFF
--- a/.github/workflows/drawio-exporter.yaml
+++ b/.github/workflows/drawio-exporter.yaml
@@ -41,9 +41,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: taiki-e/install-action@v2.86.4
-        with:
-          tool: just
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
       - name: Build
         run: just build
@@ -58,6 +56,4 @@ jobs:
         run: just clippy
 
       - name: Audit
-        run: |
-          cargo install cargo-audit
-          just audit
+        run: just audit

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -21,11 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - uses: taiki-e/install-action@v2.86.4
-        with:
-          tool: just
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
       - name: Audit
-        run: |
-          cargo install cargo-audit
-          just audit
+        run: just audit

--- a/justfile
+++ b/justfile
@@ -10,8 +10,9 @@ configure:
     @echo + $@
     rustup component add clippy
     mise install
+    cargo install cargo-tarpaulin
 
-# Execute all developements recipes
+# Execute all developments recipes
 [group('Development mode')]
 loop: fmt clippy-fix idioms-fix fix audit build test
 

--- a/justfile
+++ b/justfile
@@ -9,8 +9,7 @@ default:
 configure:
     @echo + $@
     rustup component add clippy
-    cargo install cargo-audit
-    cargo install cargo-tarpaulin
+    mise install
 
 # Execute all developements recipes
 [group('Development mode')]

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,3 @@
 [tools]
 just = "1.58.0"
 "cargo:cargo-audit" = "latest"
-"cargo:cargo-tarpaulin" = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+just = "1.58.0"
+"cargo:cargo-audit" = "latest"
+"cargo:cargo-tarpaulin" = "latest"


### PR DESCRIPTION
## Summary
- Adds `mise.toml` pinning `just` (1.58.0), `cargo-audit`, and `cargo-tarpaulin`.
- Replaces `taiki-e/install-action` + inline `cargo install cargo-audit` in `drawio-exporter.yaml` and `security-audit.yaml` with `jdx/mise-action`.
- Simplifies the `configure` justfile recipe to use `mise install`.

## Test plan
- [ ] CI passes on this PR (build/test/audit jobs)