### PR TITLE
feat: add weekly drawio-desktop version autoupdate check

### DIFF
--- a/.github/workflows/autoupdate-drawio-desktop.yaml
+++ b/.github/workflows/autoupdate-drawio-desktop.yaml
@@ -1,0 +1,42 @@
+---
+name: Autoupdate Drawio Desktop
+
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Every Monday at midnight (UTC)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: autoupdate-drawio-desktop
+  cancel-in-progress: true
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+
+      - run: just autoupdate-drawio-desktop
+        id: autoupdate-drawio-desktop
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        shell: bash
+
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        if: steps.autoupdate-drawio-desktop.outputs.release_version != ''
+        with:
+          title: "build: update to drawio-desktop ${{ steps.autoupdate-drawio-desktop.outputs.release_version }}"
+          body: ${{ steps.autoupdate-drawio-desktop.outputs.release_notes }}
+          commit-message: |
+            build: update to drawio-desktop ${{ steps.autoupdate-drawio-desktop.outputs.release_version }}
+
+            ${{ steps.autoupdate-drawio-desktop.outputs.release_notes }}
+          branch: autoupdate-drawio-desktop
+          token: ${{ secrets.GH_TOKEN }}

--- a/justfile
+++ b/justfile
@@ -81,6 +81,54 @@ coverage-view:
 deps DEPS="drawio-exporter":
     cargo tree --package {{ DEPS }}
 
+# Update drawio-desktop version used in CI
+[group('Maintenance mode')]
+autoupdate-drawio-desktop:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    WORKFLOW=.github/workflows/drawio-exporter.yaml
+    CURRENT_VERSION=$(sed -n 's/.*drawio-amd64-\([0-9.]*\)\.deb.*/\1/p' "$WORKFLOW" | head -1)
+    DRAWIO_DESKTOP_RELEASE=$(gh release list --repo jgraph/drawio-desktop | grep "Latest" | cut -f1)
+    if [ "$CURRENT_VERSION" = "$DRAWIO_DESKTOP_RELEASE" ]; then
+      echo "Already up to date ($CURRENT_VERSION)"
+      exit 0
+    fi
+    sed -i \
+      -e 's/releases\/download\/v[0-9.]*\/drawio-amd64-[0-9.]*\.deb/releases\/download\/v'$DRAWIO_DESKTOP_RELEASE'\/drawio-amd64-'$DRAWIO_DESKTOP_RELEASE'.deb/' \
+      -e 's/dpkg -i drawio-amd64-[0-9.]*\.deb/dpkg -i drawio-amd64-'$DRAWIO_DESKTOP_RELEASE'.deb/' \
+      "$WORKFLOW"
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+      echo "release_version=$DRAWIO_DESKTOP_RELEASE" >> "${GITHUB_OUTPUT}"
+
+      RELEASE_NOTES=$(gh release view "v$DRAWIO_DESKTOP_RELEASE" --repo jgraph/drawio-desktop --json body -q .body)
+      CHANGELOG=$(curl -fsSL "https://raw.githubusercontent.com/jgraph/drawio/v${DRAWIO_DESKTOP_RELEASE}/ChangeLog" || true)
+      if [ -n "$CHANGELOG" ] && grep -qE "^[0-9]{2}-[A-Z]{3}-[0-9]{4}: ${CURRENT_VERSION}$" <<< "$CHANGELOG"; then
+        CORE_CHANGES=$(awk -v old="$CURRENT_VERSION" '
+          /^[0-9]{2}-[A-Z]{3}-[0-9]{4}: / {
+            ver=$0; sub(/^[0-9]{2}-[A-Z]{3}-[0-9]{4}: /, "", ver)
+            if (ver == old) exit
+          }
+          { print }
+        ' <<< "$CHANGELOG")
+      else
+        CORE_CHANGES="See [draw.io core ChangeLog](https://github.com/jgraph/drawio/blob/v${DRAWIO_DESKTOP_RELEASE}/ChangeLog)."
+      fi
+
+      {
+        echo "release_notes<<GH_RELEASE_NOTES_EOF"
+        echo "Updates \`drawio-desktop\` from \`$CURRENT_VERSION\` to \`$DRAWIO_DESKTOP_RELEASE\`."
+        echo
+        echo "### drawio-desktop release notes"
+        echo
+        echo "$RELEASE_NOTES"
+        echo
+        echo "### draw.io core ChangeLog ($CURRENT_VERSION -> $DRAWIO_DESKTOP_RELEASE)"
+        echo
+        echo "$CORE_CHANGES"
+        echo "GH_RELEASE_NOTES_EOF"
+      } >> "${GITHUB_OUTPUT}"
+    fi
+
 # Release a new version (Possible values: major, minor, patch, release, rc, beta, alpha)
 [group('Release mode')]
 release LEVEL="alpha":

--- a/justfile
+++ b/justfile
@@ -90,43 +90,43 @@ autoupdate-drawio-desktop:
     CURRENT_VERSION=$(sed -n 's/.*drawio-amd64-\([0-9.]*\)\.deb.*/\1/p' "$WORKFLOW" | head -1)
     DRAWIO_DESKTOP_RELEASE=$(gh release list --repo jgraph/drawio-desktop | grep "Latest" | cut -f1)
     if [ "$CURRENT_VERSION" = "$DRAWIO_DESKTOP_RELEASE" ]; then
-      echo "Already up to date ($CURRENT_VERSION)"
-      exit 0
+        echo "Already up to date ($CURRENT_VERSION)"
+        exit 0
     fi
     sed -i \
-      -e 's/releases\/download\/v[0-9.]*\/drawio-amd64-[0-9.]*\.deb/releases\/download\/v'$DRAWIO_DESKTOP_RELEASE'\/drawio-amd64-'$DRAWIO_DESKTOP_RELEASE'.deb/' \
-      -e 's/dpkg -i drawio-amd64-[0-9.]*\.deb/dpkg -i drawio-amd64-'$DRAWIO_DESKTOP_RELEASE'.deb/' \
-      "$WORKFLOW"
+        -e 's/releases\/download\/v[0-9.]*\/drawio-amd64-[0-9.]*\.deb/releases\/download\/v'$DRAWIO_DESKTOP_RELEASE'\/drawio-amd64-'$DRAWIO_DESKTOP_RELEASE'.deb/' \
+        -e 's/dpkg -i drawio-amd64-[0-9.]*\.deb/dpkg -i drawio-amd64-'$DRAWIO_DESKTOP_RELEASE'.deb/' \
+        "$WORKFLOW"
     if [ -n "${GITHUB_OUTPUT:-}" ]; then
-      echo "release_version=$DRAWIO_DESKTOP_RELEASE" >> "${GITHUB_OUTPUT}"
+        echo "release_version=$DRAWIO_DESKTOP_RELEASE" >> "${GITHUB_OUTPUT}"
 
-      RELEASE_NOTES=$(gh release view "v$DRAWIO_DESKTOP_RELEASE" --repo jgraph/drawio-desktop --json body -q .body)
-      CHANGELOG=$(curl -fsSL "https://raw.githubusercontent.com/jgraph/drawio/v${DRAWIO_DESKTOP_RELEASE}/ChangeLog" || true)
-      if [ -n "$CHANGELOG" ] && grep -qE "^[0-9]{2}-[A-Z]{3}-[0-9]{4}: ${CURRENT_VERSION}$" <<< "$CHANGELOG"; then
-        CORE_CHANGES=$(awk -v old="$CURRENT_VERSION" '
-          /^[0-9]{2}-[A-Z]{3}-[0-9]{4}: / {
-            ver=$0; sub(/^[0-9]{2}-[A-Z]{3}-[0-9]{4}: /, "", ver)
-            if (ver == old) exit
-          }
-          { print }
-        ' <<< "$CHANGELOG")
-      else
-        CORE_CHANGES="See [draw.io core ChangeLog](https://github.com/jgraph/drawio/blob/v${DRAWIO_DESKTOP_RELEASE}/ChangeLog)."
-      fi
+        RELEASE_NOTES=$(gh release view "v$DRAWIO_DESKTOP_RELEASE" --repo jgraph/drawio-desktop --json body -q .body)
+        CHANGELOG=$(curl -fsSL "https://raw.githubusercontent.com/jgraph/drawio/v${DRAWIO_DESKTOP_RELEASE}/ChangeLog" || true)
+        if [ -n "$CHANGELOG" ] && grep -qE "^[0-9]{2}-[A-Z]{3}-[0-9]{4}: ${CURRENT_VERSION}$" <<< "$CHANGELOG"; then
+            CORE_CHANGES=$(awk -v old="$CURRENT_VERSION" '
+                /^[0-9]{2}-[A-Z]{3}-[0-9]{4}: / {
+                    ver=$0; sub(/^[0-9]{2}-[A-Z]{3}-[0-9]{4}: /, "", ver)
+                    if (ver == old) exit
+                }
+                { print }
+            ' <<< "$CHANGELOG")
+        else
+            CORE_CHANGES="See [draw.io core ChangeLog](https://github.com/jgraph/drawio/blob/v${DRAWIO_DESKTOP_RELEASE}/ChangeLog)."
+        fi
 
-      {
-        echo "release_notes<<GH_RELEASE_NOTES_EOF"
-        echo "Updates \`drawio-desktop\` from \`$CURRENT_VERSION\` to \`$DRAWIO_DESKTOP_RELEASE\`."
-        echo
-        echo "### drawio-desktop release notes"
-        echo
-        echo "$RELEASE_NOTES"
-        echo
-        echo "### draw.io core ChangeLog ($CURRENT_VERSION -> $DRAWIO_DESKTOP_RELEASE)"
-        echo
-        echo "$CORE_CHANGES"
-        echo "GH_RELEASE_NOTES_EOF"
-      } >> "${GITHUB_OUTPUT}"
+        {
+            echo "release_notes<<GH_RELEASE_NOTES_EOF"
+            echo "Updates \`drawio-desktop\` from \`$CURRENT_VERSION\` to \`$DRAWIO_DESKTOP_RELEASE\`."
+            echo
+            echo "### drawio-desktop release notes"
+            echo
+            echo "$RELEASE_NOTES"
+            echo
+            echo "### draw.io core ChangeLog ($CURRENT_VERSION -> $DRAWIO_DESKTOP_RELEASE)"
+            echo
+            echo "$CORE_CHANGES"
+            echo "GH_RELEASE_NOTES_EOF"
+        } >> "${GITHUB_OUTPUT}"
     fi
 
 # Release a new version (Possible values: major, minor, patch, release, rc, beta, alpha)


### PR DESCRIPTION
## Summary
- Add a `just autoupdate-drawio-desktop` recipe that checks the latest `jgraph/drawio-desktop` release, updates the version pinned in `.github/workflows/drawio-exporter.yaml`, and generates release notes (including a draw.io core ChangeLog excerpt).
- Add `.github/workflows/autoupdate-drawio-desktop.yaml`: runs weekly (Mondays) plus on `workflow_dispatch`, and opens a PR via `peter-evans/create-pull-request` when a newer version is found.

Mirrors the same pattern already used in `docker-drawio-desktop-headless`.

## Test plan
- [ ] Trigger the workflow manually (`workflow_dispatch`) and confirm it opens a PR bumping the pinned drawio-desktop version (or no-ops if already current).
- [ ] Confirm the resulting PR's CI (drawio-exporter build) passes with the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)