### PR TITLE
build: move dependabot schedule from monthly to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'cargo'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
     cooldown:
       default-days: 5
     commit-message:
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
     cooldown:
       default-days: 5
     commit-message:


### PR DESCRIPTION
Aligne le `schedule.interval` sur `weekly` pour tous les écosystèmes, en cohérence avec le reste des dépôts.

Le `cooldown.default-days: 5` est inchangé.