### PR TITLE
fix(ci): report lint results via job summary instead of PR comment

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -38,4 +38,8 @@ jobs:
           # Validated by `cargo clippy` directly in drawio-exporter.yaml file
           VALIDATE_RUST_CLIPPY: false
           VALIDATE_YAML_PRETTIER: false
+          # Fork PRs get a read-only GITHUB_TOKEN, so posting a PR comment
+          # always fails with 403. Report results as a job summary instead.
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
+          ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Super-linter's PR summary comment always fails with a 403 on fork PRs, since `GITHUB_TOKEN` is read-only for `pull_request` events triggered from forks.
- Disables `ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT` and enables `ENABLE_GITHUB_ACTIONS_STEP_SUMMARY` so results are still readable, as a GitHub Actions job summary, without needing write permissions.

## Test plan
- [x] Open a fork PR and confirm the `lint` job no longer logs a 403 for the PR comment
- [x] Confirm the job summary shows the lint results table