### PR TITLE
fix(ci): trigger Build workflow on pull_request instead of push

### DIFF
--- a/.github/workflows/drawio-exporter.yaml
+++ b/.github/workflows/drawio-exporter.yaml
@@ -1,6 +1,6 @@
 name: Build
 
-on: push
+on: pull_request
 
 env:
   RUSTFLAGS: '-Dwarnings'


### PR DESCRIPTION
## Summary
- The Build workflow (`.github/workflows/drawio-exporter.yaml`) only triggered on `push`, so it never ran on PRs opened from forks (pushes from a fork land on the fork, not this repo).
- Discovered while investigating why PR #133's checks only showed lint results, with build/test/clippy/audit silently absent.

## Test plan
- [ ] Confirm the Build workflow now runs on this PR's own checks