### PR TITLE
build: update to drawio-desktop 31.4.4

### DIFF
--- a/.github/workflows/drawio-exporter.yaml
+++ b/.github/workflows/drawio-exporter.yaml
@@ -23,8 +23,8 @@ jobs:
       - name: Preflight // Test
         run: |
           sudo apt-get install -y xvfb libnotify4 libsecret-1-0
-          wget -q https://github.com/jgraph/drawio-desktop/releases/download/v31.3.2/drawio-amd64-31.3.2.deb
-          sudo dpkg -i drawio-amd64-31.3.2.deb
+          wget -q https://github.com/jgraph/drawio-desktop/releases/download/v31.4.4/drawio-amd64-31.4.4.deb
+          sudo dpkg -i drawio-amd64-31.4.4.deb
           sudo apt-get -y -f install
 
       - name: Checkout


### PR DESCRIPTION
Updates `drawio-desktop` from `31.3.2` to `31.4.4`.

### drawio-desktop release notes

## Release Notes for 31.4.4

[Windows Installer](https://github.com/jgraph/drawio-desktop/releases/download/v31.4.4/draw.io-31.4.4-windows-installer.exe)
[Windows No Installer (zip)](https://github.com/jgraph/drawio-desktop/releases/download/v31.4.4/draw.io-31.4.4-windows.zip)
[macOS - Universal](https://github.com/jgraph/drawio-desktop/releases/download/v31.4.4/draw.io-universal-31.4.4.dmg)
Linux - [deb](https://github.com/jgraph/drawio-desktop/releases/download/v31.4.4/drawio-amd64-31.4.4.deb), [AppImage](https://github.com/jgraph/drawio-desktop/releases/download/v31.4.4/drawio-x86_64-31.4.4.AppImage) or [rpm](https://github.com/jgraph/drawio-desktop/releases/download/v31.4.4/drawio-x86_64-31.4.4.rpm)

**ChangeLog:**

- Uses electron 44.2.0
- Restricts renderer file reads to paths the user has authorised, so opening and exporting a crafted diagram can no longer read arbitrary local files through the file IPC [GHSA-fjgc-8xgj-rvh4]
- Corrects the AppImage compression method, so AppImageLauncher and other tools that expect gzip can read the image again [jgraph/drawio-desktop#2538]
- Updates to [draw.io core 31.4.4](https://github.com/jgraph/drawio/blob/v31.4.4/ChangeLog). All changes from 31.4.2 to 31.4.4 are added in this build.

**Testing:**

Verified against the packaged, signed macOS build. Linux and Windows packaging changes were verified from the produced release artifacts.

Base checks

- Launch, open a file passed on the command line, add and edit shapes, undo and redo, save, insert and delete pages
- Copy and paste through the system clipboard, which changed with Electron 44
- Export to PNG, SVG and PDF from the app and from the command line
- Diagram round trip in exported PNG, SVG and PDF, including reopening an exported PDF
- Command line page selection with -p, and --size page against the default --size diagram
- Quick Look preview on macOS renders the diagram
- The macOS bundle is signed with a Developer ID certificate under the hardened runtime and is notarised, and the Quick Look app extension is sandboxed and separately signed
- The x86_64 and arm64 AppImages are gzip compressed
- 153 unit tests pass

Read authorisation [GHSA-fjgc-8xgj-rvh4]

- readFile, fileStat, isFileWritable, watchFile, getFileDrafts, getBkpFile and checkFileExists all refuse paths the user has not authorised, including a symlink planted inside an authorised folder
- A crafted diagram whose font source points at a local file exports with nothing embedded, checked by scanning the export for the file contents in both plain and base64 form
- The font URL check rejects the evasions the URL parser would otherwise strip, being leading spaces, tabs and newlines in the scheme, uppercase schemes, and absolute, UNC and protocol relative paths, while still accepting http(s), data: and relative URLs

Checks around the read authorisation change

- Libraries and templates declared in the configuration still load, and their shapes still appear in the sidebar
- The configuration widens what may be read and not what may be written, checked by a write to a configured path being refused
- Custom libraries added in earlier versions keep working after upgrading to this build
- Drafts, backups, external change detection and the save conflict check still work
- Authorisations survive a restart, so Recent Files keeps working
- Saving a shape library opened from a file still writes without reopening the save dialog [jgraph/drawio-desktop#2518] [jgraph/drawio-desktop#2521]

### draw.io core ChangeLog (31.3.2 -> 31.4.4)

06-SEP-2026: 31.4.4

- Adds the Atlassian 2025 shape set core: glyph stencils and tile wrapper
- Adds the Atlassian sidebar palettes, agent marks and connection points
- Reworks glyph scaling in the new Atlassian library (square-canonical, per-icon hex calibration, proportional tile switching) and removes unused   logo images [jgraph/drawio#5730]
- Improves logo lockups in the new Atlassian shape library [jgraph/drawio#5730]
- Deduplicates the generated Atlassian sidebar module with shared style-prefix variables [jgraph/drawio#5730]
-  Deduplicates search tags and refreshes stale comments in the new Atlassian library [jgraph/drawio#5730]
- Moves per-icon data from styles onto the Atlassian stencil attributes [jgraph/drawio#5730]
- Hardens the Atlassian wrapper against degenerate box data [jgraph/drawio#5730]
- Guards the Atlassian wrapper's lockup layout and tile aspect against NaN [jgraph/drawio#5730]
- Hides the PlantUML and Mermaid round-trip identity attributes in tooltips
- Strips the characters the URL parser drops before the font scheme check [GHSA-fjgc-8xgj-rvh4]

05-SEP-2026: 31.4.3

- Updates stable channel to 31.4.1
- Fixes SVG attachment images rendering blank in Confluence diagrams by using the correct data URI MIME type [DID-20051]
- Retries transient network failures for GETs in the Confluence Cloud page IDs import and logs real failure totals [DID-19637]
- Rejects IPv6 transition prefixes in the server SSRF guard [GHSA-xj4f-x55f-699c]
- Stops stale image callbacks drawing ghost copies of Confluence attachment images after fit-on-load [jgraph/drawio-dev#658]
- Fixes local print preview head CSS: closes the malformed shadow-suppression rule that swallowed the MathJax print rule and configured font CSS, writes app CSS into the style element unescaped with the style end tag neutralized, rewrites Google font URLs on pages 2+ and suppresses the unnamed @page rule when named page CSS is in use
- Removes unused code
- Derives export to PDF via print and server-side image export from EXPORT_URL instead of hand-set flags, treats null, empty and the public build placeholder as no export service and fails the canvas-unavailable fallbacks instead of posting to a dead URL [jgraph/drawio-dev#660]
- Adds reindexInst3 resource for the Jira re-indexing page note that indexing pauses while the computer is asleep or offline [jgraph/drawio-jira-forge#1]
- Gives the Google API loader the page's CSP nonce in the Drive editor
- Update vendored drawio-plantuml bundle to commit 0fdd6ad
- Updates plantuml build
- Restricts font sources to http(s), data: and configured URLs [GHSA-fjgc-8xgj-rvh4]

31-AUG-2026: 31.4.2

- Keeps the CryptoJS build tooling out of the public repo [jgraph/drawio-dev#640]
- Stops an attribute value that is markup from reaching the host page [jgraph/drawio-jira#120]
- Stops the MathJax \data macro writing arbitrary data attributes [jgraph/drawio-dev#653]

28-AUG-2026: 31.4.1

- Keeps the current scale when fitting into a zero-size container [jgraph/drawio-dev#647]
- Adds a connectable switch to the connection points dialog [jgraph/drawio#5733]
- Backfills 219 missing translation keys across all 58 language files [jgraph/drawio-dev#637]
- Fixes hidden shared folders and folder shortcuts in OneDrive picker [jgraph/drawio#5359]
- Removes duplicate action, basic and mockups keys from all language files [jgraph/drawio-dev#637]
- Makes Dropbox files read-only ahead of support ending [jgraph/drawio#5740]
- Runs partial and Soundex matching on translated shape search terms [jgraph/drawio#5518]
- Updated translation of Google Drive first time file open message [DID-20062]
- Keeps placed sibling order in ELK tree layouts [jgraph/drawio#5454]
- Sets timeouts on all outbound server connections [GHSA-r85c-2h2r-46rw]
- Downscales embed mode image exports to a maximum canvas area so that huge diagrams cannot crash the renderer [DID-20081]
- Bounds the whole outbound exchange, not just each read [GHSA-r85c-2h2r-46rw]

26-AUG-2026: 31.4.0

- Bump actions/setup-node from 4.4.0 to 7.0.0
- Conf Cloud: Resolve Gliffy version pins automatically [jgraph/drawio-dev#637]
- Fixes convert worker referer gate rejecting Office add-in update requests [jgraph/drawio#5459]
- Fixes blurry Office add-in diagram updates by sending a numeric export scale [jgraph/drawio#5459]
- Rebuilds the Gliffy bundle with the value-size charge
- Removes the Gliffy conversion CF worker (import is fully client-side)
- Removes text/xml Content-Type from attachment download GETs, Confluence Cloud now rejects such GETs with 415 [#638]
- Conf Cloud: Restore Gliffy version pinning as opt-in, keep pin diagnostics [jgraph/drawio-dev#637]
- Update vendored drawio-plantuml bundle to commit ffcd9d7
- Conf Cloud: Add page IDs import error reporting strings [DID-20037]
- Follows cursor-key moves and resizes only when the selection is fully out of view, keeps the viewport static while any part is visible [jgraph/drawio-desktop#2525]
- Restores z-order actions moving table rows within the table [jgraph/drawio#5748]
- Stops resizeLast double-subtracting marginLeft in horizontal stack layouts [jgraph/drawio#5751]
- Updates vendored CryptoJS rollup to 4.2.0 for a CSPRNG-backed KDF salt [jgraph/drawio-dev#640]
- Fails closed when no CSPRNG is reachable for realtime encryption [jgraph/drawio-dev#640]
- feat(shapes): mermaidExtension + mermaidDiamond relation markers
- Places added connection points in the gaps between existing points [jgraph/drawio-desktop#2514]
- Replaces every matched color placeholder in setTextColor [jgraph/drawio-dev#644]
- Includes hand-drawn overshoot in shape bounding boxes [jgraph/drawio#5450]
- Matches only elements changed to the color placeholder [jgraph/drawio-dev#643]
- Stops nested spans accumulating on text color changes in Firefox [jgraph/drawio#5752]
- Applies text colors at a collapsed cursor to the styled run [jgraph/drawio-dev#642]
- vendor: update mermaid bundle (dev be7192b — DID-20053 gantt dateFormat/compact/vert fixes; class, architecture icon packs, kanban, radar, sankey, c4, block visual-match passes)