### PR TITLE
feat(ci): attach cross-platform binaries to GitHub releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  upload-assets:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build and upload binary
+        uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
+        with:
+          bin: drawio-exporter
+          target: ${{ matrix.target }}
+          archive: drawio-exporter-$tag-$target
+          include: LICENSE,README.adoc,CHANGELOG.md
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,4 @@
+---
 name: Release
 
 on:
@@ -33,7 +34,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build and upload binary
-        uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
+        # v1.30.2
+        uses: >-
+          taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6
         with:
           bin: drawio-exporter
           target: ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yaml`, triggered on `release: published`
- Builds and uploads `drawio-exporter` binaries for Linux, macOS, and Windows (x86_64 + arm64) using `taiki-e/upload-rust-binary-action`, with `cross` handling the aarch64-linux cross-compile automatically
- Addresses the "Add generated binaries to the release assets" item of #71

## Notes
- This only reacts to a GitHub Release being published — it doesn't create the release itself. After tagging (e.g. via `just release`), a release still needs to be published (`gh release create vX.Y.Z --generate-notes`) to trigger asset upload.
- `aarch64-pc-windows-msvc` is the riskiest target (cross-compiling arm64 Windows from an x64 runner, with git2's vendored libgit2 needing the MSVC ARM64 cross toolchain); `fail-fast: false` means the other 5 targets still upload if it fails.

## Test plan
- [ ] Publish a GitHub Release (or a test/pre-release) and confirm the workflow runs and attaches binaries for all 6 targets